### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "go run main.go"

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Note:
 -1e7 <= x <= 1e7
 Number of operations won't exceed 10000.
 The last four operations won't be called when stack is empty.
+[![Run on Repl.it](https://repl.it/badge/github/jchenriquez/716)](https://repl.it/github/jchenriquez/716)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@jchenriquez/716).